### PR TITLE
update recursiveDelete to remove links instead of crashing (-f arg bug)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,7 +74,11 @@ function recursiveDelete(delPath, callback) {
         files.forEach(function(f) {
             steps.push(function(next, err) {
                 if (err) return next(err);
-                fs.unlink(path.join(delPath, f), next);
+                if (typeof(f)==="object" && f.target !== undefined) {
+                    fs.unlink(path.join(delPath, f.target), next);
+                } else {
+                    fs.unlink(path.join(delPath, f), next);
+                };
             });
         });
         directories.reverse().forEach(function(d) {


### PR DESCRIPTION
linked files appear as objects with `source` and `target` members rather than strings

``` javascript
{ source : "/path/to/source", target : "/path/to/target" }
```
